### PR TITLE
Fix #44

### DIFF
--- a/w-AI-fu/install/py_requirements.txt
+++ b/w-AI-fu/install/py_requirements.txt
@@ -9,3 +9,4 @@ SpeechRecognition==3.10.0
 websocket_client==1.5.1
 numpy==1.24.3
 twitchio==2.6.0
+Werkzeug==2.2.2


### PR DESCRIPTION
This was because Werkzeug 3.0.0 was released and Flask does not specify the dependency correctly (the requirements say Werkzeug>=2.2.0). So Werkzeug 3.0.0 was still installed and Flask 2.2.2 was not created for Werkzeug 3.0.0.

more > https://stackoverflow.com/questions/77213053/importerror-cannot-import-name-url-quote-from-werkzeug-urls